### PR TITLE
fix(services/usenet): add missing schemas and remove manually set fom-data header

### DIFF
--- a/src/services/usenet/models/create-usenet-download-ok-response-data.ts
+++ b/src/services/usenet/models/create-usenet-download-ok-response-data.ts
@@ -7,7 +7,7 @@ export const createUsenetDownloadOkResponseData = z.lazy(() => {
   return z.object({
     authId: z.string().optional(),
     hash: z.string().optional(),
-    usenetdownloadId: z.string().optional(),
+    usenetdownloadId: z.number().optional(),
   });
 });
 
@@ -29,7 +29,7 @@ export const createUsenetDownloadOkResponseDataResponse = z.lazy(() => {
     .object({
       auth_id: z.string().optional(),
       hash: z.string().optional(),
-      usenetdownload_id: z.string().optional(),
+      usenetdownload_id: z.number().optional(),
     })
     .transform((data) => ({
       authId: data['auth_id'],
@@ -47,7 +47,7 @@ export const createUsenetDownloadOkResponseDataRequest = z.lazy(() => {
     .object({
       authId: z.string().optional(),
       hash: z.string().optional(),
-      usenetdownloadId: z.string().optional(),
+      usenetdownloadId: z.number().optional(),
     })
     .transform((data) => ({
       auth_id: data['authId'],

--- a/src/services/usenet/models/get-usenet-cached-availability-response-data.ts
+++ b/src/services/usenet/models/get-usenet-cached-availability-response-data.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+/**
+ * The shape of the model inside the application code - what the users use
+ */
+export const getUsenetCachedAvailabilityOkResponseData = z.lazy(() => {
+  return z.object({
+    name: z.string().optional(),
+    size: z.number().optional(),
+    hash: z.string().optional(),
+  });
+});
+
+/**
+ *
+ * @typedef  {GetUsenetCachedAvailabilityOkResponseData} getUsenetCachedAvailabilityOkResponseData
+ * @property {string}
+ * @property {number}
+ * @property {string}
+ */
+export type GetUsenetCachedAvailabilityOkResponseData = z.infer<typeof getUsenetCachedAvailabilityOkResponseData>;
+
+/**
+ * The shape of the model mapping from the api schema into the application shape.
+ * Is equal to application shape if all property names match the api schema
+ */
+export const getUsenetCachedAvailabilityOkResponseDataResponse = z.lazy(() => {
+  return z
+    .object({
+      name: z.string().optional(),
+      size: z.number().optional(),
+      hash: z.string().optional(),
+    })
+    .transform((data) => ({
+      name: data['name'],
+      size: data['size'],
+      hash: data['hash'],
+    }));
+});
+
+/**
+ * The shape of the model mapping from the application shape into the api schema.
+ * Is equal to application shape if all property names match the api schema
+ */
+export const getUsenetCachedAvailabilityOkResponseDataRequest = z.lazy(() => {
+  return z
+    .object({
+      name: z.string().optional(),
+      size: z.number().optional(),
+      hash: z.string().optional(),
+    })
+    .transform((data) => ({
+      name: data['name'],
+      size: data['size'],
+      hash: data['hash'],
+    }));
+});

--- a/src/services/usenet/models/get-usenet-cached-availability-response.ts
+++ b/src/services/usenet/models/get-usenet-cached-availability-response.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { getUsenetCachedAvailabilityOkResponseData, getUsenetCachedAvailabilityOkResponseDataResponse } from './get-usenet-cached-availability-response-data';
+
+/**
+ * The shape of the model inside the application code - what the users use
+ */
+export const getUsenetCachedAvailabilityOkResponse = z.lazy(() => {
+  return z.object({
+    data: z.union([z.array(getUsenetCachedAvailabilityOkResponseData), z.record(z.string(), getUsenetCachedAvailabilityOkResponseData)]).optional(),
+    detail: z.string().optional(),
+    error: z.string().optional().nullable(),
+    success: z.boolean().optional(),
+  });
+});
+
+/**
+ *
+ * @typedef  {GetUsenetCachedAvailabilityOkResponse} getUsenetCachedAvailabilityOkResponse
+ * @property {any}
+ * @property {string}
+ * @property {string}
+ * @property {boolean}
+ */
+export type GetUsenetCachedAvailabilityOkResponse = z.infer<typeof getUsenetCachedAvailabilityOkResponse>;
+
+/**
+ * The shape of the model mapping from the api schema into the application shape.
+ * Is equal to application shape if all property names match the api schema
+ */
+export const getUsenetCachedAvailabilityOkResponseResponse = z.lazy(() => {
+  return z
+    .object({
+      data: z.union([z.array(getUsenetCachedAvailabilityOkResponseDataResponse), z.record(z.string(), getUsenetCachedAvailabilityOkResponseDataResponse)]).optional(),
+      detail: z.string().optional(),
+      error: z.string().optional().nullable(),
+      success: z.boolean().optional(),
+    })
+    .transform((data) => ({
+      data: data['data'],
+      detail: data['detail'],
+      error: data['error'],
+      success: data['success'],
+    }));
+});
+
+/**
+ * The shape of the model mapping from the application shape into the api schema.
+ * Is equal to application shape if all property names match the api schema
+ */
+export const getUsenetCachedAvailabilityOkResponseRequest = z.lazy(() => {
+  return z
+    .object({
+      data: z.union([z.array(getUsenetCachedAvailabilityOkResponseDataResponse), z.record(z.string(), getUsenetCachedAvailabilityOkResponseDataResponse)]).optional(),
+      detail: z.string().optional(),
+      error: z.string().optional().nullable(),
+      success: z.boolean().optional(),
+    })
+    .transform((data) => ({
+      data: data['data'],
+      detail: data['detail'],
+      error: data['error'],
+      success: data['success'],
+    }));
+});

--- a/src/services/usenet/models/request-download-link-response.ts
+++ b/src/services/usenet/models/request-download-link-response.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+/**
+ * The shape of the model inside the application code - what the users use
+ */
+export const requestDownloadLinkOkResponse = z.lazy(() => {
+  return z.object({
+    data: z.string().optional(),
+    detail: z.string().optional(),
+    error: z.any().optional().nullable(),
+    success: z.boolean().optional(),
+  });
+});
+
+/**
+ *
+ * @typedef  {RequestDownloadLinkOkResponse} requestDownloadLinkOkResponse
+ * @property {string}
+ * @property {string}
+ * @property {any}
+ * @property {boolean}
+ */
+export type RequestDownloadLinkOkResponse = z.infer<typeof requestDownloadLinkOkResponse>;
+
+/**
+ * The shape of the model mapping from the api schema into the application shape.
+ * Is equal to application shape if all property names match the api schema
+ */
+export const requestDownloadLinkOkResponseResponse = z.lazy(() => {
+  return z
+    .object({
+      data: z.string().optional(),
+      detail: z.string().optional(),
+      error: z.any().optional().nullable(),
+      success: z.boolean().optional(),
+    })
+    .transform((data) => ({
+      data: data['data'],
+      detail: data['detail'],
+      error: data['error'],
+      success: data['success'],
+    }));
+});
+
+/**
+ * The shape of the model mapping from the application shape into the api schema.
+ * Is equal to application shape if all property names match the api schema
+ */
+export const requestDownloadLinkOkResponseRequest = z.lazy(() => {
+  return z
+    .object({
+      data: z.string().optional(),
+      detail: z.string().optional(),
+      error: z.any().optional().nullable(),
+      success: z.boolean().optional(),
+    })
+    .transform((data) => ({
+      data: data['data'],
+      detail: data['detail'],
+      error: data['error'],
+      success: data['success'],
+    }));
+});

--- a/src/services/usenet/usenet-service.ts
+++ b/src/services/usenet/usenet-service.ts
@@ -15,6 +15,8 @@ import {
 import { _8 } from './models/_8';
 import { GetUsenetCachedAvailabilityParams, GetUsenetListParams, RequestDownloadLink1Params } from './request-params';
 import { GetUsenetListOkResponse, getUsenetListOkResponseResponse } from './models/get-usenet-list-ok-response';
+import { RequestDownloadLinkOkResponse, requestDownloadLinkOkResponseResponse } from './models/request-download-link-response';
+import { GetUsenetCachedAvailabilityOkResponse, getUsenetCachedAvailabilityOkResponseResponse } from './models/get-usenet-cached-availability-response';
 
 export class UsenetService extends BaseService {
   /**
@@ -68,7 +70,6 @@ Requires an API key using the Authorization Bearer Header.
         key: 'api_version',
         value: apiVersion,
       })
-      .addHeaderParam({ key: 'Content-Type', value: 'multipart/form-data' })
       .addBody(body)
       .build();
     return this.client.call<CreateUsenetDownloadOkResponse>(request);
@@ -149,13 +150,13 @@ Requires an API key as a parameter for the `token` parameter.
  * @param {string} [params.userIp] - The user's IP to determine the closest CDN. Optional.
  * @param {string} [params.redirect] - If you want to redirect the user to the CDN link. This is useful for creating permalinks so that you can just make this request URL the link.
  * @param {RequestConfig} requestConfig - (Optional) The request configuration for retry and validation.
- * @returns {Promise<HttpResponse<any>>} 
+ * @returns {Promise<HttpResponse<RequestDownloadLinkOkResponse>>} 
  */
-  async requestDownloadLink1(
+  async requestDownloadLink(
     apiVersion: string,
     params?: RequestDownloadLink1Params,
     requestConfig?: RequestConfig,
-  ): Promise<HttpResponse<void>> {
+  ): Promise<HttpResponse<RequestDownloadLinkOkResponse>> {
     const request = new RequestBuilder()
       .setBaseUrl(requestConfig?.baseUrl || this.config.baseUrl || this.config.environment || Environment.DEFAULT)
       .setConfig(this.config)
@@ -167,6 +168,11 @@ Requires an API key as a parameter for the `token` parameter.
       .addResponse({
         schema: z.undefined(),
         contentType: ContentType.NoContent,
+        status: 307,
+      })
+      .addResponse({
+        schema: requestDownloadLinkOkResponseResponse,
+        contentType: ContentType.Json,
         status: 200,
       })
       .setRetryAttempts(this.config, requestConfig)
@@ -201,7 +207,7 @@ Requires an API key as a parameter for the `token` parameter.
         value: params?.redirect,
       })
       .build();
-    return this.client.call<void>(request);
+    return this.client.call<RequestDownloadLinkOkResponse>(request);
   }
 
   /**
@@ -283,13 +289,13 @@ Requires an API key using the Authorization Bearer Header.
  * @param {string} [params.hash] - The list of usenet hashes you want to check. Comma seperated. To find the hash, md5 the link of the usenet link or file.
  * @param {string} [params.format] - Format you want the data in. Acceptable is either "object" or "list". List is the most performant option as it doesn't require modification of the list.
  * @param {RequestConfig} requestConfig - (Optional) The request configuration for retry and validation.
- * @returns {Promise<HttpResponse<any>>} 
+ * @returns {Promise<HttpResponse<GetUsenetCachedAvailabilityOkResponse>>} 
  */
   async getUsenetCachedAvailability(
     apiVersion: string,
     params?: GetUsenetCachedAvailabilityParams,
     requestConfig?: RequestConfig,
-  ): Promise<HttpResponse<void>> {
+  ): Promise<HttpResponse<GetUsenetCachedAvailabilityOkResponse>> {
     const request = new RequestBuilder()
       .setBaseUrl(requestConfig?.baseUrl || this.config.baseUrl || this.config.environment || Environment.DEFAULT)
       .setConfig(this.config)
@@ -299,8 +305,8 @@ Requires an API key using the Authorization Bearer Header.
       .addAccessTokenAuth(this.config.token, 'Bearer')
       .setRequestContentType(ContentType.Json)
       .addResponse({
-        schema: z.undefined(),
-        contentType: ContentType.NoContent,
+        schema: getUsenetCachedAvailabilityOkResponseResponse,
+        contentType: ContentType.Json,
         status: 200,
       })
       .setRetryAttempts(this.config, requestConfig)
@@ -319,6 +325,6 @@ Requires an API key using the Authorization Bearer Header.
         value: params?.format,
       })
       .build();
-    return this.client.call<void>(request);
+    return this.client.call<GetUsenetCachedAvailabilityOkResponse>(request);
   }
 }


### PR DESCRIPTION
Added missing response schemas.

Removed:
```js
      .addHeaderParam({ key: 'Content-Type', value: 'multipart/form-data' })
```

As manually setting it prevents the boundary from being added causing this error: 
```json
{"detail": "Missing boundary in multipart" }
```